### PR TITLE
Fix messagebox resize at lower and upper boundary

### DIFF
--- a/LeUI-BG1EE/copy/UI.menu
+++ b/LeUI-BG1EE/copy/UI.menu
@@ -14225,7 +14225,13 @@ function dragMessagesY(newY)
 
 	--lower bound on height, sliced rects can't get too small and we don't want to make the message box invisible.
 	--also don't go too high because it looks bad.
-	if hNew > 50 and hNew < 450 then
+	if hNew < 50 then
+		newY = h - 50
+	elseif hNew > 450 then
+		newY = h - 450
+	end
+
+	if newY ~= 0 then
 		adjustItemGroup({"messagesHandleY"},0,newY,0,0)
 		adjustItemGroup({"messagesRect","worldMessageBox"},0,newY,0,-newY)
 	end


### PR DESCRIPTION
Instead of not resizing the messagebox at all if the new height is outside the allowed range, clamp the delta `newY` appropriately in order to allow resizing to the lower or upper boundary.

In particular, this fixes the PgUp and PgDown keys not resizing the messagebox if the current height is less than 20 pixels away from the minimum or maximum height.

This fix can also be applied to the BG2EE and SoD skins of LeUI.